### PR TITLE
Add stats and buffer size

### DIFF
--- a/pcapobj.cc
+++ b/pcapobj.cc
@@ -57,6 +57,7 @@ static PyObject* p_setnonblock(register pcapobject* pp, PyObject* args);
 static PyObject* p_getnonblock(register pcapobject* pp, PyObject* args);
 static PyObject* p_dump_open(register pcapobject* pp, PyObject* args);
 static PyObject* p_sendpacket(register pcapobject* pp, PyObject* args);
+static PyObject* p_stats( register pcapobject* pp, PyObject*);
 
 static PyMethodDef p_methods[] = {
   {"loop", (PyCFunction) p_loop, METH_VARARGS, "loops packet dispatching"},
@@ -70,6 +71,7 @@ static PyMethodDef p_methods[] = {
   {"setnonblock", (PyCFunction) p_setnonblock, METH_VARARGS, "puts into `non-blocking' mode, or take it out, depending on the argument"},
   {"dump_open", (PyCFunction) p_dump_open, METH_VARARGS, "creates a dumper object"},
   {"sendpacket", (PyCFunction) p_sendpacket, METH_VARARGS, "sends a packet through the interface"},
+  {"stats", (PyCFunction) p_stats, METH_NOARGS, "returns capture statistics"},
   {NULL, NULL}	/* sentinel */
 };
 
@@ -374,6 +376,25 @@ p_dispatch(register pcapobject* pp, PyObject* args)
   }
 
   return Py_BuildValue("i", ret);
+}
+
+static PyObject*
+p_stats(register pcapobject* pp, PyObject*)
+{
+  if (Py_TYPE(pp) != &Pcaptype)
+     {
+	   PyErr_SetString(PcapError, "Not a pcap object");
+	   return NULL;
+	 }
+
+  struct pcap_stat stats;
+
+  if (-1 == pcap_stats(pp->pcap, &stats)) {
+     PyErr_SetString(PcapError, pcap_geterr(pp->pcap));
+	 return NULL;
+  }
+
+	return Py_BuildValue("III", stats.ps_recv, stats.ps_drop, stats.ps_ifdrop);
 }
 
 static PyObject*

--- a/pcapy.cc
+++ b/pcapy.cc
@@ -79,14 +79,15 @@ open_live(PyObject *self, PyObject *args)
   int  snaplen;
   int  promisc;
   int  to_ms;
+  int buffer;
 
   bpf_u_int32 net, mask;
+  int status;
 
-
-  if(!PyArg_ParseTuple(args,"siii:open_live",&device,&snaplen,&promisc,&to_ms))
+  if(!PyArg_ParseTuple(args,"siii|i:open_live",&device,&snaplen,&promisc,&to_ms,&buffer))
     return NULL;
 
-  int status = pcap_lookupnet(device, &net, &mask, errbuff);
+  status = pcap_lookupnet(device, &net, &mask, errbuff);
   if(status)
     {
       net = 0;
@@ -95,12 +96,30 @@ open_live(PyObject *self, PyObject *args)
 
   pcap_t* pt;
 
-  pt = pcap_open_live(device, snaplen, promisc!=0, to_ms, errbuff);
+  pt = pcap_create(device, errbuff);
   if(!pt)
     {
       PyErr_SetString(PcapError, errbuff);
       return NULL;
     }
+
+  pcap_set_snaplen(pt, snaplen);
+  pcap_set_promisc(pt, promisc!=0);
+  pcap_set_timeout(pt, to_ms);
+
+  if(!buffer)
+    {
+      buffer = 0; // sets to libpcap default
+    }
+  pcap_set_buffer_size(pt, buffer);
+
+  status = pcap_activate(pt);
+  if(status)
+    {
+      PyErr_SetString(PcapError, "Failed to activate");
+      return NULL;
+    }
+
 #ifdef WIN32
   pcap_setmintocopy(pt, 0);
 #endif
@@ -173,7 +192,7 @@ bpf_compile(PyObject* self, PyObject* args)
 
 
 static PyMethodDef pcap_methods[] = {
-  {"open_live", open_live, METH_VARARGS, "open_live(device, snaplen, promisc, to_ms) opens a pcap device"},
+  {"open_live", open_live, METH_VARARGS, "open_live(device, snaplen, promisc, to_ms, buffer) opens a pcap device"},
   {"open_offline", open_offline, METH_VARARGS, "open_offline(filename) opens a pcap formated file"},
   {"lookupdev", lookupdev, METH_VARARGS, "lookupdev() looks up a pcap device"},
   {"findalldevs", findalldevs, METH_VARARGS, "findalldevs() lists all available interfaces"},

--- a/pcapy.xml
+++ b/pcapy.xml
@@ -53,6 +53,9 @@
             <paramdef>
               int <parameter>to_ms</parameter>
             </paramdef>
+            <paramdef>
+              int <parameter>buffer</parameter>
+            </paramdef>
           </funcprototype>
         </funcsynopsis>
       </refsynopsisdiv>
@@ -84,6 +87,9 @@
           kernel in one operation. Not all platforms support a read
           timeout; on platforms that don't, the read timeout is
           ignored.
+          <parameter>buffer</parameter> sets the buffer size that
+          will be used on a capture handle when the handle is activated
+          to buffer, which is in units of bytes.
         </para>
       </refsect1>
     </refentry>
@@ -363,6 +369,32 @@
           <parameter>header</parameter> is a
           <classname>Pkthdr</classname> instance describing the data
           passed and <parameter>data</parameter> is the data itself.
+        </para>
+      </refsect1>
+    </refentry>
+
+    <refentry>
+      <refnamediv>
+        <refname>stats</refname>
+        <refpurpose>get capture statistics</refpurpose>
+      </refnamediv>
+
+      <refsynopsisdiv>
+        <funcsynopsis>
+          <funcprototype>
+            <funcdef>
+              (int32, int32, int32) <function>stats</function>
+            </funcdef>
+            <void/>
+          </funcprototype>
+        </funcsynopsis>
+      </refsynopsisdiv>
+
+      <refsect1>
+        <title>DESCRIPTION</title>
+        <para>
+          <function>stats</function> returns statistics on the current
+          capture as a tuple (recv, drop, ifdrop)
         </para>
       </refsect1>
     </refentry>


### PR DESCRIPTION
Addresses #5 and is a fresher duplicate of PR #8 

This leans on the 1.0 libpcap API, so may not be something you want to merge if you want to keep that 0.7.2 compatibility listed in the README.

It does maintain backwards compatibility with the pcapy API for `open_live` however, by making buffer specification optional.

This is my first C++ in a long time, so forgive foibles - It Works For Me™. Happy to rework it or split into separate PRs if more convenient.

Thanks for making this library available!
