### PR TITLE
Build Windows wheels and test using Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,43 @@
+environment:
+
+  global:
+    # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the
+    # /E:ON and /V:ON options are not enabled in the batch script intepreter
+    # See: http://stackoverflow.com/a/13751649/163740
+    WITH_COMPILER: "cmd /E:ON /V:ON /C .\\appveyor\\run_with_compiler.cmd"
+    DISTRIBUTIONS: "bdist_wheel"
+
+  matrix:
+    - PYTHON: "C:\\Python27"
+      PYTHON_VERSION: "2.7.11"
+      PYTHON_ARCH: "32"
+
+init:
+  - "ECHO %PYTHON% %PYTHON_VERSION% %PYTHON_ARCH%"
+
+install:
+  - cinst winpcap
+  - "powershell appveyor\\install.ps1"
+  - "set HOME=%APPVEYOR_BUILD_FOLDER%"
+  - "set WPDPACK_BASE=%APPVEYOR_BUILD_FOLDER%\\WpdPack"
+  - "%PYTHON%/python -m pip install -U pip"  # Upgrade pip
+  - "%WITH_COMPILER% %PYTHON%/python setup.py build"
+  - "%WITH_COMPILER% %PYTHON%/python setup.py %DISTRIBUTIONS%"
+  - ps: "ls dist"
+
+  # Install the wheel to test it
+  - "%PYTHON%/python -m pip install --ignore-installed --pre --no-index --find-links dist/ pcapy"
+
+# Appveyor's build step is specific to .NET projects, so we build in the
+# install step instead.
+build: off
+
+test_script:
+  - "cd tests"
+  - "%PYTHON%/python pcapytests.py"
+
+  # Move back to the project folder
+  - "cd .."
+
+artifacts:
+  - path: dist\*

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,6 +12,26 @@ environment:
       PYTHON_VERSION: "2.7.11"
       PYTHON_ARCH: "32"
 
+    - PYTHON: "C:\\Python34"
+      PYTHON_VERSION: "3.4.3"
+      PYTHON_ARCH: "32"
+
+    - PYTHON: "C:\\Python35"
+      PYTHON_VERSION: "3.5.0"
+      PYTHON_ARCH: "32"
+
+    - PYTHON: "C:\\Python27-x64"
+      PYTHON_VERSION: "2.7.11"
+      PYTHON_ARCH: "64"
+
+    - PYTHON: "C:\\Python34-x64"
+      PYTHON_VERSION: "3.4.3"
+      PYTHON_ARCH: "64"
+
+    - PYTHON: "C:\\Python35-x64"
+      PYTHON_VERSION: "3.5.0"
+      PYTHON_ARCH: "64"
+
 init:
   - "ECHO %PYTHON% %PYTHON_VERSION% %PYTHON_ARCH%"
 

--- a/appveyor/install.ps1
+++ b/appveyor/install.ps1
@@ -3,7 +3,7 @@ function InstallPackage ($python_home, $pkg) {
     & $pip_path install $pkg
 }
 
-function DownloadPrebuilt () {
+function DownloadWinpcapDev () {
     $webclient = New-Object System.Net.WebClient
 
     $download_url = "https://www.winpcap.org/install/bin/WpdPack_4_1_2.zip"

--- a/appveyor/install.ps1
+++ b/appveyor/install.ps1
@@ -1,0 +1,42 @@
+function InstallPackage ($python_home, $pkg) {
+    $pip_path = $python_home + "/Scripts/pip.exe"
+    & $pip_path install $pkg
+}
+
+function DownloadPrebuilt () {
+    $webclient = New-Object System.Net.WebClient
+
+    $download_url = "https://www.winpcap.org/install/bin/WpdPack_4_1_2.zip"
+    $filename = "WpdPack_4_1_2.zip"
+    
+    $basedir = $pwd.Path + "\"
+    $filepath = $basedir + $prebuilt_zip
+    if (Test-Path $filepath) {
+        Write-Host "Reusing" $filepath
+        return $filepath
+    }
+
+    # Download and retry up to 5 times in case of network transient errors.
+    Write-Host "Downloading" $filename "from" $download_url
+    $retry_attempts = 3
+    for($i=0; $i -lt $retry_attempts; $i++){
+        try {
+            $webclient.DownloadFile($download_url, $filepath)
+            break
+        }
+        Catch [Exception]{
+            Start-Sleep 1
+        }
+   }
+   Write-Host "File saved at" $filepath
+
+   & 7z x $filename
+}
+
+
+function main () {
+    InstallPackage $env:PYTHON wheel
+    & DownloadWinpcapDev
+}
+
+main

--- a/appveyor/install.ps1
+++ b/appveyor/install.ps1
@@ -10,7 +10,7 @@ function DownloadWinpcapDev () {
     $filename = "WpdPack_4_1_2.zip"
     
     $basedir = $pwd.Path + "\"
-    $filepath = $basedir + $prebuilt_zip
+    $filepath = $basedir + $filename
     if (Test-Path $filepath) {
         Write-Host "Reusing" $filepath
         return $filepath

--- a/appveyor/run_with_compiler.cmd
+++ b/appveyor/run_with_compiler.cmd
@@ -1,0 +1,88 @@
+:: To build extensions for 64 bit Python 3, we need to configure environment
+:: variables to use the MSVC 2010 C++ compilers from GRMSDKX_EN_DVD.iso of:
+:: MS Windows SDK for Windows 7 and .NET Framework 4 (SDK v7.1)
+::
+:: To build extensions for 64 bit Python 2, we need to configure environment
+:: variables to use the MSVC 2008 C++ compilers from GRMSDKX_EN_DVD.iso of:
+:: MS Windows SDK for Windows 7 and .NET Framework 3.5 (SDK v7.0)
+::
+:: 32 bit builds, and 64-bit builds for 3.5 and beyond, do not require specific
+:: environment configurations.
+::
+:: Note: this script needs to be run with the /E:ON and /V:ON flags for the
+:: cmd interpreter, at least for (SDK v7.0)
+::
+:: More details at:
+:: https://github.com/cython/cython/wiki/64BitCythonExtensionsOnWindows
+:: http://stackoverflow.com/a/13751649/163740
+::
+:: Author: Olivier Grisel
+:: License: CC0 1.0 Universal: http://creativecommons.org/publicdomain/zero/1.0/
+::
+:: Notes about batch files for Python people:
+::
+:: Quotes in values are literally part of the values:
+::      SET FOO="bar"
+:: FOO is now five characters long: " b a r "
+:: If you don't want quotes, don't include them on the right-hand side.
+::
+:: The CALL lines at the end of this file look redundant, but if you move them
+:: outside of the IF clauses, they do not run properly in the SET_SDK_64==Y
+:: case, I don't know why.
+@ECHO OFF
+
+SET COMMAND_TO_RUN=%*
+SET WIN_SDK_ROOT=C:\Program Files\Microsoft SDKs\Windows
+SET WIN_WDK=c:\Program Files (x86)\Windows Kits\10\Include\wdf
+
+:: Extract the major and minor versions, and allow for the minor version to be
+:: more than 9.  This requires the version number to have two dots in it.
+SET MAJOR_PYTHON_VERSION=%PYTHON_VERSION:~0,1%
+IF "%PYTHON_VERSION:~3,1%" == "." (
+    SET MINOR_PYTHON_VERSION=%PYTHON_VERSION:~2,1%
+) ELSE (
+    SET MINOR_PYTHON_VERSION=%PYTHON_VERSION:~2,2%
+)
+
+:: Based on the Python version, determine what SDK version to use, and whether
+:: to set the SDK for 64-bit.
+IF %MAJOR_PYTHON_VERSION% == 2 (
+    SET WINDOWS_SDK_VERSION="v7.0"
+    SET SET_SDK_64=Y
+) ELSE (
+    IF %MAJOR_PYTHON_VERSION% == 3 (
+        SET WINDOWS_SDK_VERSION="v7.1"
+        IF %MINOR_PYTHON_VERSION% LEQ 4 (
+            SET SET_SDK_64=Y
+        ) ELSE (
+            SET SET_SDK_64=N
+            IF EXIST "%WIN_WDK%" (
+                :: See: https://connect.microsoft.com/VisualStudio/feedback/details/1610302/
+                REN "%WIN_WDK%" 0wdf
+            )
+        )
+    ) ELSE (
+        ECHO Unsupported Python version: "%MAJOR_PYTHON_VERSION%"
+        EXIT 1
+    )
+)
+
+IF %PYTHON_ARCH% == 64 (
+    IF %SET_SDK_64% == Y (
+        ECHO Configuring Windows SDK %WINDOWS_SDK_VERSION% for Python %MAJOR_PYTHON_VERSION% on a 64 bit architecture
+        SET DISTUTILS_USE_SDK=1
+        SET MSSdk=1
+        "%WIN_SDK_ROOT%\%WINDOWS_SDK_VERSION%\Setup\WindowsSdkVer.exe" -q -version:%WINDOWS_SDK_VERSION%
+        "%WIN_SDK_ROOT%\%WINDOWS_SDK_VERSION%\Bin\SetEnv.cmd" /x64 /release
+        ECHO Executing: %COMMAND_TO_RUN%
+        call %COMMAND_TO_RUN% || EXIT 1
+    ) ELSE (
+        ECHO Using default MSVC build environment for 64 bit architecture
+        ECHO Executing: %COMMAND_TO_RUN%
+        call %COMMAND_TO_RUN% || EXIT 1
+    )
+) ELSE (
+    ECHO Using default MSVC build environment for 32 bit architecture
+    ECHO Executing: %COMMAND_TO_RUN%
+    call %COMMAND_TO_RUN% || EXIT 1
+)

--- a/setup.py
+++ b/setup.py
@@ -12,10 +12,18 @@ library_dirs = []
 libraries = []
 
 if sys.platform == 'win32':
-    # WinPcap include files
-    include_dirs.append(r'c:\devel\oss\wpdpack\Include')
-    # WinPcap library files
-    library_dirs.append(r'c:\devel\oss\wpdpack\Lib')
+    if os.environ.get('WPDPACK_BASE'):
+        wpdpack = os.environ['WPDPACK_BASE']
+        include_dirs.append(os.path.join(wpdpack, 'Include'))
+        if sys.maxsize > 2**32:  # x64 Python interpreter
+            library_dirs.append(os.path.join(wpdpack, 'Lib', 'x64'))
+        else:  # x86 Python interpreter
+            library_dirs.append(os.path.join(wpdpack, 'Lib'))
+    else:
+        # WinPcap include files
+        include_dirs.append(r'c:\devel\oss\wpdpack\Include')
+        # WinPcap library files
+        library_dirs.append(r'c:\devel\oss\wpdpack\Lib')
     libraries = ['wpcap', 'packet', 'ws2_32']
 else:
     libraries = ['pcap', 'stdc++']

--- a/tests/pcapytests.py
+++ b/tests/pcapytests.py
@@ -121,13 +121,11 @@ class TestPcapy(unittest.TestCase):
 
             self.assertTrue(h1 is None)
             self.assertTrue(h2 is None)
+            del r2
+        finally:
             os.unlink('tmp.pcap')
-        except Exception:
-            try:
-                os.unlink('tmp.pcap')
-            except Exception:
-                pass
-            raise  # bubble up exception so test fails
 
 suite = unittest.TestLoader().loadTestsFromTestCase(TestPcapy)
-unittest.TextTestRunner(verbosity=2).run(suite)
+result = unittest.TextTestRunner(verbosity=2).run(suite)
+if not result.wasSuccessful():
+    sys.exit(1)


### PR DESCRIPTION
This builds Windows wheels for several Python versions using the Appveyor CI service, and then tests them. You can see the build from this branch here:
https://ci.appveyor.com/project/takluyver/pcapy

The tests are failing in some cases:

```
======================================================================
FAIL: testEOFValue (__main__.TestPcapy)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "pcapytests.py", line 50, in testEOFValue
    self.assertEqual(pkt, b'')
AssertionError: None != b''
----------------------------------------------------------------------
Ran 4 tests in 0.000s
```

The value of `pkt` comes from Py_BuildValue on [this line](https://github.com/CoreSecurity/pcapy/blob/37179f5b6187ec58d3ba11ef7b24e3c341cbabbb/pcapobj.cc#L282). The [docs for Py_BuildValue](https://docs.python.org/3/c-api/arg.html#c.Py_BuildValue) say that passing in a NULL pointer for a bytes field will result in None. `buf` is an output parameter from [pcap_next_ex](http://www.tcpdump.org/manpages/pcap_next_ex.3pcap.html), and if a packet is not read, it is not set.

I think this was introduced by commit 3a582a96cce284a3ee0b9ee2d6bc82fd57d9efcd, which changed the code from using `pcap_next` to `pcap_next_ex`.
