### PR TITLE
bpfobject support get_bpf method

### DIFF
--- a/bpfobj.cc
+++ b/bpfobj.cc
@@ -37,11 +37,13 @@ PyObject* BPFError;
 
 // BPFProgram methods
 static PyObject* p_filter(register bpfobject* bpf, PyObject* args);
+static PyObject* p_get_bpf(register bpfobject* bpf, PyObject* args);
 static PyObject* p_new_bpfobject(PyTypeObject *type, PyObject* args, PyObject *kwags);
 
 
 static PyMethodDef bpf_methods[] = {
   {"filter", (PyCFunction) p_filter, METH_VARARGS, "filter(packet) applies the filter to the packet, returns 0 if there's no match"},
+  {"get_bpf", (PyCFunction) p_get_bpf, METH_NOARGS, "return packet-matching code as decimal numbers"},
   {NULL, NULL}	/* sentinel */
 };
 
@@ -210,4 +212,38 @@ p_filter(register bpfobject* bpf, PyObject* args)
 		      len, len);
 
   return Py_BuildValue("i", status);
+}
+
+static PyObject*
+p_get_bpf(register bpfobject* bpf, PyObject* args)
+{
+  struct bpf_insn *insn;
+  int i;
+  int n = bpf->bpf.bf_len;
+  PyObject* list;
+  PyObject* instruction;
+
+  insn = bpf->bpf.bf_insns;
+
+  if (Py_TYPE(bpf) != &BPFProgramType)
+    {
+      PyErr_SetString(BPFError, "Not a bpfprogram object");
+      return NULL;
+    }
+
+  list = PyList_New(n);
+  if (!list) {
+      return NULL;
+  }
+
+  for (i = 0; i < n; ++insn, ++i) {
+      instruction = Py_BuildValue("IIII", insn->code, insn->jt, insn->jf, insn->k);
+      if (!instruction) {
+          Py_DECREF(list);
+          return NULL;
+      }
+      PyList_SET_ITEM(list, i, instruction);
+  }
+
+  return list;
 }

--- a/tests/pcapytests.py
+++ b/tests/pcapytests.py
@@ -148,21 +148,15 @@ class TestPcapy(unittest.TestCase):
             r.next()
 
     def test_get_bpf(self):
-        bpf = pcapy.compile(pcapy.DLT_EN10MB, 2**16, "tcp", 1, 1)
+        bpf = pcapy.compile(pcapy.DLT_EN10MB, 2**16, "icmp", 1, 1)
         code = bpf.get_bpf()
 
-        # result of `tcpdump "tcp" -ddd -s 65536` on EN10MB interface
-        expected = """12
+        # result of `tcpdump "icmp" -ddd -s 65536` on EN10MB interface
+        expected = """6
 40 0 0 12
-21 0 5 34525
-48 0 0 20
-21 6 0 6
-21 0 6 44
-48 0 0 54
-21 3 4 6
 21 0 3 2048
 48 0 0 23
-21 0 1 6
+21 0 1 1
 6 0 0 65536
 6 0 0 0"""
 

--- a/tests/pcapytests.py
+++ b/tests/pcapytests.py
@@ -169,7 +169,7 @@ class TestPcapy(unittest.TestCase):
         result = str(len(code)) + "\n"
         result += "\n".join([' '.join(map(str, inst)) for inst in code])
 
-        assert result == expected
+        self.assertEqual(expected, result)
 
 
 suite = unittest.TestLoader().loadTestsFromTestCase(TestPcapy)

--- a/tests/pcapytests.py
+++ b/tests/pcapytests.py
@@ -147,6 +147,31 @@ class TestPcapy(unittest.TestCase):
         with self.assertRaises(ValueError):
             r.next()
 
+    def test_get_bpf(self):
+        bpf = pcapy.compile(pcapy.DLT_EN10MB, 2**16, "tcp", 1, 1)
+        code = bpf.get_bpf()
+
+        # result of `tcpdump "tcp" -ddd -s 65536` on EN10MB interface
+        expected = """12
+40 0 0 12
+21 0 5 34525
+48 0 0 20
+21 6 0 6
+21 0 6 44
+48 0 0 54
+21 3 4 6
+21 0 3 2048
+48 0 0 23
+21 0 1 6
+6 0 0 65536
+6 0 0 0"""
+
+        result = str(len(code)) + "\n"
+        result += "\n".join([' '.join(map(str, inst)) for inst in code])
+
+        assert result == expected
+
+
 suite = unittest.TestLoader().loadTestsFromTestCase(TestPcapy)
 result = unittest.TextTestRunner(verbosity=2).run(suite)
 if not result.wasSuccessful():


### PR DESCRIPTION
This PR add support for the bpfobject in a get_bpf method that returns a packet-matching code as decimal numbers very similar to tcpdump -ddd. For example:

```py
import pcapy
b = pcapy.compile(pcapy.DLT_EN10MB, 2**16, "tcp", 1, 255)
b.get_bpf()
[(40, 0, 0, 12),
 (21, 0, 5, 34525),
 (48, 0, 0, 20),
 (21, 6, 0, 6),
 (21, 0, 6, 44),
 (48, 0, 0, 54),
 (21, 3, 4, 6),
 (21, 0, 3, 2048),
 (48, 0, 0, 23),
 (21, 0, 1, 6),
 (6, 0, 0, 65536),
 (6, 0, 0, 0)]
```
