### PR TITLE
Add a close method & context manager to Reader to allow explicit resource cleanup

### DIFF
--- a/tests/pcapytests.py
+++ b/tests/pcapytests.py
@@ -125,6 +125,28 @@ class TestPcapy(unittest.TestCase):
         finally:
             os.unlink('tmp.pcap')
 
+    def testClose(self):
+        """
+        #7 Test the close method
+        """
+        r = pcapy.open_offline(TestPcapy._96PINGS)
+        hdr, body = r.next()
+        assert hdr is not None
+        r.close()
+        with self.assertRaises(ValueError):
+            r.next()
+
+    def testContextManager(self):
+        """
+        #8 Test the context manager support
+        """
+        with pcapy.open_offline(TestPcapy._96PINGS) as r:
+            hdr, body = r.next()
+            assert hdr is not None
+
+        with self.assertRaises(ValueError):
+            r.next()
+
 suite = unittest.TestLoader().loadTestsFromTestCase(TestPcapy)
 result = unittest.TextTestRunner(verbosity=2).run(suite)
 if not result.wasSuccessful():


### PR DESCRIPTION
This allows the user to explicitly close the `Pcap`/`Reader` object like he can do to most Python objects that hold OS/library resources, and it now also functions as a context manager:

```python
import pcapy

with pcapy.open_live(pcapy.findalldevs()[0], 65535, True, 100) as r:
    hdr, pkt = r.next()
    while hdr is not None:
        # ...
        hdr, pkt = r.next()
```

I had to add `tp_methods` to the type object as the context manager protocol doesn't seem to call `__getattr__` (Why wasn't it there in the first place...? I think the `__getattr__` can really be removed...).

Fixes #30 