### PR TITLE
Fixes DeprecationWarning

### DIFF
--- a/pcapobj.cc
+++ b/pcapobj.cc
@@ -7,6 +7,7 @@
  *
  */
 
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 #include <pcap.h>
 


### PR DESCRIPTION
DeprecationWarning: PY_SSIZE_T_CLEAN will be required for '#' formats (Reference: https://docs.python.org/3/c-api/intro.html)