### PR TITLE
fix compilation on Windows with WinPcap 4.1.2 Dev's Pack

### DIFF
--- a/pcapy.h
+++ b/pcapy.h
@@ -21,7 +21,8 @@ static char* luid_to_guid(char *luid);
 #endif
 
 #if PY_MAJOR_VERSION >= 3
-PyObject * PyInit_pcapy(void);
+PyMODINIT_FUNC
+PyInit_pcapy(void);
 #else
 void initpcapy(void);
 #endif


### PR DESCRIPTION
Error:
...
pcapy.cc(270): error C2375: 'PyInit_pcapy' : redefinition; different linkage
pcapy.h(24): see declaration of 'PyInit_pcapy'
...