### PR TITLE
Remove deprecated PyEval_CallObject call

### DIFF
--- a/pcapobj.cc
+++ b/pcapobj.cc
@@ -409,7 +409,7 @@ PythonCallBack(u_char *user,
   arglist = Py_BuildValue("Os#", hdr, packetdata, *len);
 #endif
 
-  result = PyEval_CallObject(pctx->pyfunc,arglist);
+  result = PyObject_CallObject(pctx->pyfunc,arglist);
 
   Py_XDECREF(arglist);
   if (result)


### PR DESCRIPTION
PyEval_CallObject is removed from python3.13 use PyObject_CallObject() instead.

Issue originally reported [here](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1081430)